### PR TITLE
6-SpringBaseExecution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,13 +22,13 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.3.1'
-    compileOnly 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.3.1'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.3.1'
+    compileOnly 'org.projectlombok:lombok'
 }
 
 tasks.named('bootBuildImage') {


### PR DESCRIPTION
# 개요
- 프로젝트 gradle setting 하기.
- 관련 issue: https://github.com/ParansaikStudy/LDK-SpringBase/issues/6

### 1. build.gradel setting
  ![image](https://github.com/ParansaikStudy/LDK-SpringBase/assets/30463982/df313678-914b-4b86-acfb-4ad73e41486f)

- group은 약어 com 사용.
- version 관리는 추후 배포 때 수정하겠음.

### 2. Dependencies
- dependencies 코드 부분 
```
dependencies {
    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.3.1'
    implementation 'org.springframework.boot:spring-boot-starter-web'
    testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.3.1'
    testImplementation 'org.springframework.boot:spring-boot-starter-test'
    developmentOnly 'org.springframework.boot:spring-boot-devtools'
    annotationProcessor 'org.projectlombok:lombok'
    compileOnly 'org.projectlombok:lombok'
}
```
  ![image](https://github.com/ParansaikStudy/LDK-SpringBase/assets/30463982/a9a1b03c-65f5-4504-b241-5fbb5705aafa)

- spring-boot-starter-web: RESTful 웹 서비스, Spring MVC를 포함하여 웹 애플리케이션을 빠르게 구축.
- spring-boot-devtolls: 코드 변경 시 자동으로 애플리케이션을 다시 시작하고, 클래스패스에 변경된 리소스를 감지하여 적용하는 등의 기능 제공.
- lombok: 어노테이션을 사용하여 간결한 코드 작성과 반복적인 코드의 줄임을 위해 추가.